### PR TITLE
Refactor the last intermediary mapping reference to Mojang mappings

### DIFF
--- a/src/main/java/me/lntricate/intricarpet/mixins/interactions/NaturalSpawnerMixin.java
+++ b/src/main/java/me/lntricate/intricarpet/mixins/interactions/NaturalSpawnerMixin.java
@@ -10,6 +10,14 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.NaturalSpawner;
 
+//#if MC < 11800
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import me.lntricate.intricarpet.interfaces.IChunkMap;
+import net.minecraft.world.level.NaturalSpawner.SpawnState;
+import net.minecraft.world.level.chunk.LevelChunk;
+//#endif
+
 @Mixin(NaturalSpawner.class)
 public class NaturalSpawnerMixin
 {
@@ -18,4 +26,15 @@ public class NaturalSpawnerMixin
   {
     return self.getNearestPlayer(a, b, c, d, entity -> !(entity instanceof IServerPlayer player && !player.getInteraction(Interaction.MOBSPAWNING)));
   }
+
+  //#if MC < 11800
+  // The only vanilla caller, ServerChunkCache#tickChunks, invokes this from a synthetic lambda that
+  // has no Mojang name to target, so the condition is applied on this side instead.
+  @Inject(method = "spawnForChunk(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/level/chunk/LevelChunk;Lnet/minecraft/world/level/NaturalSpawner$SpawnState;ZZZ)V", at = @At("HEAD"), cancellable = true)
+  private static void shouldSpawnMobs(ServerLevel level, LevelChunk levelChunk, SpawnState a, boolean b, boolean c, boolean d, CallbackInfo ci)
+  {
+    if(!((IChunkMap)level.getChunkSource().chunkMap).anyPlayerCloseWithInteraction(levelChunk.getPos(), Interaction.MOBSPAWNING))
+      ci.cancel();
+  }
+  //#endif
 }

--- a/src/main/java/me/lntricate/intricarpet/mixins/interactions/ServerChunkCacheMixin.java
+++ b/src/main/java/me/lntricate/intricarpet/mixins/interactions/ServerChunkCacheMixin.java
@@ -1,20 +1,22 @@
 package me.lntricate.intricarpet.mixins.interactions;
 
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
 
-import com.llamalad7.mixinextras.injector.WrapWithCondition;
-
-import me.lntricate.intricarpet.interactions.Interaction;
-import me.lntricate.intricarpet.interfaces.IChunkMap;
-import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ServerChunkCache;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.level.NaturalSpawner.SpawnState;
-import net.minecraft.world.level.chunk.LevelChunk;
+
+//#if MC >= 11800
+//$$ import org.spongepowered.asm.mixin.Final;
+//$$ import org.spongepowered.asm.mixin.Shadow;
+//$$ import org.spongepowered.asm.mixin.Unique;
+//$$ import org.spongepowered.asm.mixin.injection.At;
+//$$ import com.llamalad7.mixinextras.injector.WrapWithCondition;
+//$$ import me.lntricate.intricarpet.interactions.Interaction;
+//$$ import me.lntricate.intricarpet.interfaces.IChunkMap;
+//$$ import net.minecraft.server.level.ChunkMap;
+//$$ import net.minecraft.server.level.ServerLevel;
+//$$ import net.minecraft.world.level.NaturalSpawner.SpawnState;
+//$$ import net.minecraft.world.level.chunk.LevelChunk;
+//#endif
 
 //#if MC >= 12100
 //$$ import java.util.List;
@@ -25,66 +27,66 @@ import net.minecraft.world.level.chunk.LevelChunk;
 //$$ import java.util.function.Consumer;
 //#endif
 
+// On MC < 1.18 the mob spawning and random tick calls live inside a synthetic lambda in
+// ServerChunkCache#tickChunks, which has no Mojang name to target. Those two conditions are
+// applied on the callee side instead, see NaturalSpawnerMixin and ServerLevelMixin.
 @Mixin(ServerChunkCache.class)
 public class ServerChunkCacheMixin
 {
-  @Final
-  @Shadow
-  public ChunkMap chunkMap;
-
-  @Unique
-  private static final String targetMethod =
-  //#if MC >= 12105
-  //$$ "tickChunks(Lnet/minecraft/util/profiling/ProfilerFiller;J)V";
-  //#elseif MC >= 12102
-  //$$ "tickChunks(Lnet/minecraft/util/profiling/ProfilerFiller;JLjava/util/List;)V";
-  //#elseif MC >= 11800
-  //$$ "tickChunks()V";
-  //#else
-    "method_20801";
-  //#endif
-
-  //#if MC >= 12105
-  //$$ @WrapWithCondition(method = "tickSpawningChunk", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/NaturalSpawner;spawnForChunk(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/level/chunk/LevelChunk;Lnet/minecraft/world/level/NaturalSpawner$SpawnState;Ljava/util/List;)V"))
-  //$$ private boolean shouldSpawnMobs(ServerLevel a, LevelChunk levelChunk, SpawnState b, List c)
-  //#elseif MC >= 12102
-  //$$ @WrapWithCondition(method = targetMethod, at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/NaturalSpawner;spawnForChunk(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/level/chunk/LevelChunk;Lnet/minecraft/world/level/NaturalSpawner$SpawnState;Ljava/util/List;)V"))
-  //$$ private boolean shouldSpawnMobs(ServerLevel a, LevelChunk levelChunk, SpawnState b, List c)
-  //#else
-  @WrapWithCondition(method = targetMethod, at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/NaturalSpawner;spawnForChunk(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/level/chunk/LevelChunk;Lnet/minecraft/world/level/NaturalSpawner$SpawnState;ZZZ)V"))
-  private boolean shouldSpawnMobs(ServerLevel a, LevelChunk levelChunk, SpawnState b, boolean c, boolean d, boolean e)
-  //#endif
-  {
-    return ((IChunkMap)chunkMap).anyPlayerCloseWithInteraction(levelChunk.getPos(), Interaction.MOBSPAWNING);
-  }
-
-  //#if MC >= 12105
-  //$$ @Redirect(
-  //$$         method = targetMethod,
-  //$$         at = @At(
-  //$$                 value = "INVOKE",
-  //$$                 target = "Lnet/minecraft/server/level/ChunkMap;forEachBlockTickingChunk(Ljava/util/function/Consumer;)V"
-  //$$         )
-  //$$ )
-  //$$ private void redirectForEachBlockTickingChunk(ChunkMap chunkMapInstance, Consumer<LevelChunk> originalConsumer) {
-  //$$   Consumer<LevelChunk> wrapper = (levelChunk) -> {
-  //$$     try {
-  //$$       boolean should = ((IChunkMap)chunkMapInstance)
-  //$$               .anyPlayerCloseWithInteraction(levelChunk.getPos(), Interaction.RANDOMTICKS);
-  //$$       if (should) {
-  //$$         originalConsumer.accept(levelChunk);
-  //$$       }
-  //$$     } catch (Throwable t) {
-  //$$       t.printStackTrace();
-  //$$     }
-  //$$   };
-  //$$   chunkMapInstance.forEachBlockTickingChunk(wrapper);
+  //#if MC >= 11800
+  //$$ @Final
+  //$$ @Shadow
+  //$$ public ChunkMap chunkMap;
+  //$$ @Unique
+  //$$ private static final String targetMethod =
+    //#if MC >= 12105
+    //$$ "tickChunks(Lnet/minecraft/util/profiling/ProfilerFiller;J)V";
+    //#elseif MC >= 12102
+    //$$ "tickChunks(Lnet/minecraft/util/profiling/ProfilerFiller;JLjava/util/List;)V";
+    //#else
+    //$$ "tickChunks()V";
+    //#endif
+    //#if MC >= 12105
+    //$$ @WrapWithCondition(method = "tickSpawningChunk", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/NaturalSpawner;spawnForChunk(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/level/chunk/LevelChunk;Lnet/minecraft/world/level/NaturalSpawner$SpawnState;Ljava/util/List;)V"))
+    //$$ private boolean shouldSpawnMobs(ServerLevel a, LevelChunk levelChunk, SpawnState b, List c)
+    //#elseif MC >= 12102
+    //$$ @WrapWithCondition(method = targetMethod, at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/NaturalSpawner;spawnForChunk(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/level/chunk/LevelChunk;Lnet/minecraft/world/level/NaturalSpawner$SpawnState;Ljava/util/List;)V"))
+    //$$ private boolean shouldSpawnMobs(ServerLevel a, LevelChunk levelChunk, SpawnState b, List c)
+    //#else
+    //$$ @WrapWithCondition(method = targetMethod, at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/NaturalSpawner;spawnForChunk(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/level/chunk/LevelChunk;Lnet/minecraft/world/level/NaturalSpawner$SpawnState;ZZZ)V"))
+    //$$ private boolean shouldSpawnMobs(ServerLevel a, LevelChunk levelChunk, SpawnState b, boolean c, boolean d, boolean e)
+    //#endif
+  //$$ {
+  //$$   return ((IChunkMap)chunkMap).anyPlayerCloseWithInteraction(levelChunk.getPos(), Interaction.MOBSPAWNING);
   //$$ }
-  //#else
-  @WrapWithCondition(method = targetMethod, at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;tickChunk(Lnet/minecraft/world/level/chunk/LevelChunk;I)V"))
-  private boolean shouldRandomTick(ServerLevel instance, LevelChunk levelChunk, int i)
-  {
-    return ((IChunkMap)chunkMap).anyPlayerCloseWithInteraction(levelChunk.getPos(), Interaction.RANDOMTICKS);
-  }
+    //#if MC >= 12105
+    //$$ @Redirect(
+    //$$         method = targetMethod,
+    //$$         at = @At(
+    //$$                 value = "INVOKE",
+    //$$                 target = "Lnet/minecraft/server/level/ChunkMap;forEachBlockTickingChunk(Ljava/util/function/Consumer;)V"
+    //$$         )
+    //$$ )
+    //$$ private void redirectForEachBlockTickingChunk(ChunkMap chunkMapInstance, Consumer<LevelChunk> originalConsumer) {
+    //$$   Consumer<LevelChunk> wrapper = (levelChunk) -> {
+    //$$     try {
+    //$$       boolean should = ((IChunkMap)chunkMapInstance)
+    //$$               .anyPlayerCloseWithInteraction(levelChunk.getPos(), Interaction.RANDOMTICKS);
+    //$$       if (should) {
+    //$$         originalConsumer.accept(levelChunk);
+    //$$       }
+    //$$     } catch (Throwable t) {
+    //$$       t.printStackTrace();
+    //$$     }
+    //$$   };
+    //$$   chunkMapInstance.forEachBlockTickingChunk(wrapper);
+    //$$ }
+    //#else
+    //$$ @WrapWithCondition(method = targetMethod, at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;tickChunk(Lnet/minecraft/world/level/chunk/LevelChunk;I)V"))
+    //$$ private boolean shouldRandomTick(ServerLevel instance, LevelChunk levelChunk, int i)
+    //$$ {
+    //$$   return ((IChunkMap)chunkMap).anyPlayerCloseWithInteraction(levelChunk.getPos(), Interaction.RANDOMTICKS);
+    //$$ }
+    //#endif
   //#endif
 }

--- a/src/main/java/me/lntricate/intricarpet/mixins/interactions/ServerLevelMixin.java
+++ b/src/main/java/me/lntricate/intricarpet/mixins/interactions/ServerLevelMixin.java
@@ -1,0 +1,30 @@
+package me.lntricate.intricarpet.mixins.interactions;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import net.minecraft.server.level.ServerLevel;
+
+//#if MC < 11800
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import me.lntricate.intricarpet.interactions.Interaction;
+import me.lntricate.intricarpet.interfaces.IChunkMap;
+import net.minecraft.world.level.chunk.LevelChunk;
+//#endif
+
+// On MC >= 1.18 the random tick condition is applied at the call site in ServerChunkCacheMixin, so
+// this mixin only carries a body on the older versions where that call site sits inside a synthetic
+// lambda with no Mojang name to target.
+@Mixin(ServerLevel.class)
+public class ServerLevelMixin
+{
+  //#if MC < 11800
+  @Inject(method = "tickChunk(Lnet/minecraft/world/level/chunk/LevelChunk;I)V", at = @At("HEAD"), cancellable = true)
+  private void shouldRandomTick(LevelChunk levelChunk, int i, CallbackInfo ci)
+  {
+    if(!((IChunkMap)((ServerLevel)(Object)this).getChunkSource().chunkMap).anyPlayerCloseWithInteraction(levelChunk.getPos(), Interaction.RANDOMTICKS))
+      ci.cancel();
+  }
+  //#endif
+}

--- a/src/main/resources/intricarpet.mixins.json
+++ b/src/main/resources/intricarpet.mixins.json
@@ -16,6 +16,7 @@
     "interactions.ProjectileMixin",
     "interactions.ServerChunkCacheMixin",
     "interactions.ServerGamePacketListenerImplMixin",
+    "interactions.ServerLevelMixin",
     "interactions.ServerPlayerMixin"
   ],
   "client": [


### PR DESCRIPTION
Every version already built against officialMojangMappings(), but ServerChunkCacheMixin still hardcoded the intermediary name "method_20801" for MC < 1.18.

That symbol is the synthetic lambda inside 1.17.1's ServerChunkCache#tickChunks -- the chunkMap.getChunks().forEach(...) body, descriptor (JZLNaturalSpawner$SpawnState;ZILChunkHolder;)V. Synthetic lambdas have no Mojang name that survives remapping, so the hardcoded intermediary name only resolves in a production (intermediary) runtime and fails to apply in a Mojang-mapped dev run.

Move the two conditions for MC < 1.18 off the lambda and onto the callees, which do have Mojang names:

- NaturalSpawner#spawnForChunk gains a cancellable HEAD injection carrying the mob spawning check
- new interactions/ServerLevelMixin cancels ServerLevel#tickChunk for the random tick check

ServerChunkCache#tickChunks is the only vanilla call site of either method on 1.17.1, so behaviour is unchanged.

MC >= 1.18 keeps the existing call-site injections; the generated source for those versions is identical apart from import ordering.